### PR TITLE
Add financial chatbot

### DIFF
--- a/financial_chatbot.html
+++ b/financial_chatbot.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Financial Chatbot</title>
+    <link rel="stylesheet" href="mobile.css">
+    <link rel="stylesheet" href="tablestyles_c.css">
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        #chatbox { border: 1px solid #ccc; padding: 10px; height: 300px; overflow-y: auto; margin-bottom: 10px; }
+        #message { width: 80%; padding: 8px; }
+        #send { padding: 8px 12px; }
+    </style>
+</head>
+<body>
+    <h1>Financial Chatbot</h1>
+    <div id="chatbox"></div>
+    <input type="text" id="message" placeholder="Ask a financial question" />
+    <button id="send">Send</button>
+    <script src="financial_chatbot.js"></script>
+</body>
+</html>

--- a/financial_chatbot.js
+++ b/financial_chatbot.js
@@ -1,0 +1,29 @@
+const chatbox = document.getElementById('chatbox');
+const messageInput = document.getElementById('message');
+const sendButton = document.getElementById('send');
+
+async function sendMessage() {
+  const message = messageInput.value.trim();
+  if (!message) return;
+  chatbox.innerHTML += `<p><strong>You:</strong> ${message}</p>`;
+  messageInput.value = '';
+  try {
+    const response = await fetch('/api/financial-chatbot', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message })
+    });
+    const data = await response.json();
+    chatbox.innerHTML += `<p><strong>Bot:</strong> ${data.response}</p>`;
+  } catch (err) {
+    chatbox.innerHTML += `<p><strong>Error:</strong> Unable to get response.</p>`;
+  }
+  chatbox.scrollTop = chatbox.scrollHeight;
+}
+
+sendButton.addEventListener('click', sendMessage);
+messageInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    sendMessage();
+  }
+});

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -1,5 +1,5 @@
 import os
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from flask_cors import CORS
 import psycopg2
 
@@ -52,6 +52,15 @@ def get_batting_stats():
         })
 
     return jsonify(stats_list)
+
+
+@app.route('/api/financial-chatbot', methods=['POST'])
+def financial_chatbot():
+    """Simple placeholder endpoint for a financial chatbot."""
+    data = request.get_json(silent=True) or {}
+    message = data.get('message', '')
+    response_text = f"This is a placeholder financial response for: {message}"
+    return jsonify({"response": response_text})
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0")

--- a/index.html
+++ b/index.html
@@ -535,7 +535,9 @@ footer a:hover {
                     </ul>
                 </li>
                 <li class = 'nav-item'><a href="mailto:agneya2208@gmail.com">Contact</a></li>
-                <li class = 'nav-item'><a href="archives.html">Archives</a></li></ul>
+                <li class = 'nav-item'><a href="archives.html">Archives</a></li>
+                <li class='nav-item'><a class='nav-link' href="financial_chatbot.html">Financial Chatbot</a></li>
+            </ul>
     </header>
 
     <!-- Hero Section -->


### PR DESCRIPTION
## Summary
- Add placeholder `/api/financial-chatbot` endpoint in Flask backend
- Create Financial Chatbot page and script for user interaction
- Link Financial Chatbot page in site navigation

## Testing
- `python -m py_compile flask_app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a59b658ffc832383da9c3717801f9a